### PR TITLE
Add Elephant Bird Hive Lib

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -95,6 +95,11 @@
   <dependencies>
     <!-- dependencies are always listed in sorted order by groupId, artifectId -->
     <dependency>
+      <groupId>com.twitter.elephantbird</groupId>
+      <artifactId>elephant-bird-hive</artifactId>
+      <version>4.15</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-common</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Add the dependency EB Hive.
We are using the EB's ``com.twitter.elephantbird.mapred.input.HiveMultiInputFormat`` as the ``InputFormat`` for LZO Thrift Format data. If we want to manually modify the table properties, for example, ``elephantbird.mapred.input.bad.record.threshold``, we will see the error like:

```
0: jdbc:hive2://sdzktest.smf1.twitter.com:218> ALTER TABLE logs_sms_audits_thrift_lzo SET TBLPROPERTIES ('elephantbird.mapred.input.bad.record.threshold' = '0.001');
Error: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. com.twitter.elephantbird.mapred.input.HiveMultiInputFormat (state=08S01,code=1)
```

We could add the EB Hive as a dependency in the Hive package to solve this error.