### PR TITLE
Fix travis failures in twitter/branch-2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ dist: trusty
 # parallel builds on jdk7 and jdk8
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 cache:
@@ -35,7 +34,7 @@ cache:
 
 env:
   MAVEN_SKIP_RC=true
-  MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M"
+  MAVEN_OPTS="-Xmx2g"
 
 # workaround added: https://github.com/travis-ci/travis-ci/issues/4629
 before_install:
@@ -44,4 +43,4 @@ before_install:
 
 install: true
 
-script: mvn clean install -DskipTests -T 4 -q -Pitests
+script: mvn clean install -DskipTests -q -Pitests


### PR DESCRIPTION
Travis is failing because of 
1. `JAVA_HOME` not set, change `jdk` to `oraclejdk8` fix this issue.
2.  build timeout, remove `-T 4` fix this issue.