### PR TITLE
fix column name underscore bug

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -16,7 +16,6 @@ package org.apache.hadoop.hive.ql.io.parquet.read;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -96,7 +95,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
    */
   private static Type getFieldTypeIgnoreCase(GroupType groupType, String fieldName) {
     for (Type type : groupType.getFields()) {
-      if (type.getName().equalsIgnoreCase(fieldName)) {
+      if (type.getName().equalsIgnoreCase(fieldName) || (type.getName() + "_").equalsIgnoreCase(fieldName)) {
         return type;
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -95,12 +95,16 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
    */
   private static Type getFieldTypeIgnoreCase(GroupType groupType, String fieldName) {
     for (Type type : groupType.getFields()) {
-      //TODO: add unit test for w/ and w/o underscore
-      if (type.getName().equalsIgnoreCase(fieldName) || (type.getName() + "_").equalsIgnoreCase(fieldName)) {
+      if (type.getName().equalsIgnoreCase(fieldName)) {
         return type;
       }
     }
-
+    //TODO: add unit test for w/ and w/o underscore
+    for (Type type : groupType.getFields()) {
+      if ((type.getName() + "_").equalsIgnoreCase(fieldName)) {
+        return type;
+      }
+    }
     return null;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -95,6 +95,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
    */
   private static Type getFieldTypeIgnoreCase(GroupType groupType, String fieldName) {
     for (Type type : groupType.getFields()) {
+      //TODO: add unit test for w/ and w/o underscore
       if (type.getName().equalsIgnoreCase(fieldName) || (type.getName() + "_").equalsIgnoreCase(fieldName)) {
         return type;
       }

--- a/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -354,7 +354,7 @@ public class SessionManager extends CompositeService {
    * @param withImpersonation
    * @param delegationToken
    * @return
-   * @throws HiveSQLException
+   * @throws HiveSQLExceptiontype.getName().equalsIgnoreCase(fieldName
    */
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password, String ipAddress,
       Map<String, String> sessionConf, boolean withImpersonation, String delegationToken)

--- a/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -354,7 +354,7 @@ public class SessionManager extends CompositeService {
    * @param withImpersonation
    * @param delegationToken
    * @return
-   * @throws HiveSQLExceptiontype.getName().equalsIgnoreCase(fieldName
+   * @throws HiveSQLException
    */
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password, String ipAddress,
       Map<String, String> sessionConf, boolean withImpersonation, String delegationToken)


### PR DESCRIPTION
An underscore in column name 'timestamp_' was appended to avoid using 'timestamp', which is a reserved keyword in hive metadata. However, this creates issue passing schema which contains 'timestamp_' to parquet data on HDFS, which has 'timestamp' as column name.

In this fix, we force both '${column_name}' and '${column_name}_' equal to '${column_name}' to resolve above corner case.