### PR TITLE
Add unit test to hive query logging

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryStats.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryStats.java
@@ -16,8 +16,6 @@ public class QueryStats {
   private String IPAddress;
   private String username;
   private String database;
-  private String mapReduceStatsDesc;
-  private String currentTimeStamp;
   private ArrayList<taskDetail> taskProgress;
   private ArrayList<plan> planProgress;
   private Map<String, MapRedStats> mapReduceStats;
@@ -137,22 +135,6 @@ public class QueryStats {
 
   public String getDatabase() {
     return this.database;
-  }
-
-  public void setMapReduceStatsDesc(String MapReduceStatsDesc) {
-    this.mapReduceStatsDesc = MapReduceStatsDesc;
-  }
-
-  public String getMapReduceStatsDesc() {
-    return this.mapReduceStatsDesc;
-  }
-
-  public void setCurrentTimeStamp(String currentTimeStamp) {
-    this.currentTimeStamp = currentTimeStamp;
-  }
-
-  public String getCurrentTimeStamp() {
-    return this.currentTimeStamp;
   }
 
   public ArrayList<taskDetail> getTaskProgress() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/history/QueryCompletedEventScriber.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/history/QueryCompletedEventScriber.java
@@ -55,7 +55,7 @@ public class QueryCompletedEventScriber {
 
   private static final Logger LOG = LoggerFactory.getLogger("hive.ql.exec.HiveScribeImpl");
 
-  private static TwitterScriber scriber = new TwitterScriber("hive_query_completion");
+  protected TwitterScriber scriber = new TwitterScriber("hive_query_completion");
 
   public void handle(QueryStats event) {
     try {
@@ -154,16 +154,18 @@ public class QueryCompletedEventScriber {
       return;
     }
     for (Map.Entry<String, MapRedStats> ent : mapReduceInfo.entrySet()) {
-      QueryStageInfo thriftCounterInfo = new QueryStageInfo();
+      QueryStageInfo thriftStageInfo = new QueryStageInfo();
       String key = ent.getKey();
-      thriftCounterInfo.setStageId(key);
-      thriftCounterInfo.setJobId(ent.getValue().getJobId());
-      thriftCounterInfo.setCpuMsec(ent.getValue().getCpuMSec());
-      thriftCounterInfo.setCounters(ent.getValue().getCounters().toString());
-      thriftCounterInfo.setNumberMappers(ent.getValue().getNumMap());
-      thriftCounterInfo.setNumberReducers(ent.getValue().getNumReduce());
-      thriftCounterInfo.setTaskNumbers(ent.getValue().getTaskNumbers());
-      thriftMapReduceInfo.put(key, thriftCounterInfo);
+      thriftStageInfo.setStageId(key);
+      thriftStageInfo.setJobId(ent.getValue().getJobId());
+      thriftStageInfo.setCpuMsec(ent.getValue().getCpuMSec());
+      if (ent.getValue().getCounters() != null) {
+        thriftStageInfo.setCounters(ent.getValue().getCounters().toString());
+      }
+      thriftStageInfo.setNumberMappers(ent.getValue().getNumMap());
+      thriftStageInfo.setNumberReducers(ent.getValue().getNumReduce());
+      thriftStageInfo.setTaskNumbers(ent.getValue().getTaskNumbers());
+      thriftMapReduceInfo.put(key, thriftStageInfo);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/history/TwitterScriber.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/history/TwitterScriber.java
@@ -73,7 +73,7 @@ public class TwitterScriber
     return Base64.getEncoder().encodeToString(serializer.get().serialize(thriftMessage));
   }
 
-  private void scribe(String message)
+  protected void scribe(String message)
   {
     LogRecord logRecord = new LogRecord(Level.ALL, message);
     queueingHandler.publish(logRecord);

--- a/ql/src/test/org/apache/hadoop/hive/ql/history/TestHiveScribeImpl.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/history/TestHiveScribeImpl.java
@@ -1,0 +1,150 @@
+package org.apache.hadoop.hive.ql.history;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.MapRedStats;
+import org.apache.hadoop.hive.ql.QueryPlan;
+import org.apache.hadoop.hive.ql.plan.api.Query;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.thrift.hive.HiveQueryCompletionEvent;
+import org.apache.thrift.TException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class TestHiveScribeImpl {
+  private HiveScribeImpl hiveScriber = null;
+  private TwitterScriber twitterScriber = null;
+  private SessionState sessionState = null;
+  private Map<String, MapRedStats> mapRedStats;
+  private MapRedStats oneMapRedStats;
+  private QueryPlan plan;
+  private String queryId;
+  private String queryString;
+  private String username;
+  private String ipAddress;
+  private String sessionId;
+  private String dataBase;
+  private String planInfoFormat;
+  private String taskName;
+  private String taskId;
+  private String taskProgress;
+  private String taskStart;
+  private String taskEnd;
+  private String taskInfoFormat;
+  private String mapRedKey;
+  private Long queryStartTime;
+  private Long queryEndTime;
+  private Long taskStartTime;
+  private Long taskProgressTime;
+  private Long taskEndTime;
+  private Long planTime;
+
+  @Before
+  public void beforeEachTest() {
+    hiveScriber = new HiveScribeImpl();
+    queryId = "hive_20181011015254_49c74d55-7833-4063-9ba4-a4d8d0271ae0";
+    queryString = "describe iesource.client_engagements";
+    username = "user";
+    ipAddress = "10.53.211.120";
+    sessionId = "2aae61d4-374f-4f29-9076-432372003fc2";
+    dataBase = "default";
+    queryStartTime = Long.parseLong("1539222821986");
+    queryEndTime = Long.parseLong("1539223547219");
+
+    taskName = "org.apache.hadoop.hive.ql.exec.DDLTask";
+    taskId = "Stage-0";
+    taskStartTime = Long.parseLong("1539222821986");
+    taskProgressTime = Long.parseLong("1539222821986");
+    taskEndTime = Long.parseLong("1539222821986");
+    taskInfoFormat = String.format("TASK_NAME=\"%s\" QUERY_ID=\"%s\" TASK_ID=\"%s\"", taskName, queryId, taskId);
+    taskStart = "TaskStart " + taskInfoFormat;
+    taskProgress = "TaskProgress " + taskInfoFormat;
+    taskEnd = "TaskEnd " + taskInfoFormat;
+
+    planTime = Long.parseLong("1539222821986");
+    planInfoFormat = String.format("PlanInfo(timeStamp:%s, planDetails:PlanDetails(queryId:%s, stageGraph:GraphInfo(), stageList:[], done:[], started:[]))", planTime, queryId);
+    plan = new QueryPlan();
+    plan.setQueryId(queryId);
+    plan.setQuery(new Query());
+
+    oneMapRedStats = new MapRedStats(1, 1, 10, true, "1");
+    mapRedStats = new HashMap();
+    mapRedKey = "Stage 1";
+    mapRedStats.put(mapRedKey, oneMapRedStats);
+  }
+
+  @Test
+  public void testStartQueryMissingSessionState() {
+    hiveScriber.startQuery(queryString, queryId, null, queryStartTime);
+
+    assertTrue(hiveScriber.getQueryStatsMap().keySet().size() == 0);
+  }
+
+  @Test
+  public void testEntireQueryCycle() throws TException, IOException {
+    // Start query
+    sessionState = Mockito.mock(SessionState.class);
+    when(sessionState.getUserName()).thenReturn(username);
+    when(sessionState.getUserIpAddress()).thenReturn(ipAddress);
+    when(sessionState.getSessionId()).thenReturn(sessionId);
+    when(sessionState.getCurrentDatabase()).thenReturn(dataBase);
+    when(sessionState.getMapRedStats()).thenReturn(mapRedStats);
+
+    twitterScriber = Mockito.mock(TwitterScriber.class);
+    hiveScriber.hiveHistScriber.scriber = twitterScriber;
+
+    hiveScriber.startQuery(queryString, queryId, sessionState, queryStartTime);
+
+    assertTrue(hiveScriber.getQueryStatsMap().keySet().size() == 1);
+    assertTrue(hiveScriber.getQueryStatsMap().keySet().contains(queryId));
+    assertEquals(queryId, hiveScriber.getQueryStatsMap().get(queryId).getQueryId());
+    assertEquals(queryString, hiveScriber.getQueryStatsMap().get(queryId).getQueryString());
+    assertEquals((long) queryStartTime, hiveScriber.getQueryStatsMap().get(queryId).getStartTime());
+
+    // Start Task
+    hiveScriber.startTask(queryId, taskId, taskName, taskStartTime);
+    assertTrue(hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().size() == 1);
+    assertEquals(taskStart, hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().get(0).getProgress());
+
+    // Progress Task
+    hiveScriber.progressTask(queryId, taskId, taskProgressTime);
+    assertTrue(hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().size() == 2);
+    assertEquals(taskProgress, hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().get(1).getProgress());
+
+    // End Task
+    hiveScriber.endTask(queryId, taskId, taskEndTime);
+    assertTrue(hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().size() == 3);
+    assertEquals(taskEnd, hiveScriber.getQueryStatsMap().get(queryId).getTaskProgress().get(2).getProgress());
+
+    // Progress Plan
+    hiveScriber.logPlanProgress(plan, planTime);
+
+    // End query
+    hiveScriber.endQuery(queryId, sessionState, queryEndTime);
+
+    // Capture log event at scribe()
+    ArgumentCaptor<HiveQueryCompletionEvent> arg = ArgumentCaptor.forClass(HiveQueryCompletionEvent.class);
+    Mockito.verify(hiveScriber.hiveHistScriber.scriber).scribe(arg.capture());
+    HiveQueryCompletionEvent tEvent = arg.getValue();
+
+    assertEquals(queryId, tEvent.queryId);
+    assertEquals(queryString, tEvent.queryString);
+    assertEquals(username, tEvent.user);
+    assertEquals(ipAddress, tEvent.ip);
+    assertEquals(sessionId, tEvent.sessionId);
+    assertEquals(dataBase, tEvent.database);
+    assertEquals((long) queryEndTime, tEvent.endTime);
+    assertEquals((long) queryStartTime, tEvent.startTime);
+    assertEquals(mapRedStats.get(mapRedKey).getNumMap(), tEvent.getMapReduceStats().get(mapRedKey).getNumberMappers());
+    assertEquals(mapRedStats.get(mapRedKey).getNumReduce(), tEvent.getMapReduceStats().get(mapRedKey).getNumberReducers());
+    assertEquals((long) planTime, tEvent.getPlanProgress().get(0).getTimeStamp());
+    assertEquals(queryId, tEvent.getPlanProgress().get(0).getPlanDetails().getQueryId());
+    assertEquals(planInfoFormat, tEvent.getPlanProgress().get(0).toString());
+  }
+}


### PR DESCRIPTION
This pull request added unit test to hive query logging. 
1. Refactor code to be testable: decoupled locally created variables by adding parameters at interface, and changed **twitterscriber** to be **Protected** from **Private**. 
2. Remove unused fields in QueryStats: currentTimeStamp and mapReduceStatsDesc, and their accessor methods.
3. Clean up confusing variable names: renamed thriftCounterInfo to thriftStageInfo. 
4. Add unit test.