### PR TITLE
Fix null string exception in getLocation()

### DIFF
--- a/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
+++ b/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/StorageDescriptor.java
@@ -341,6 +341,9 @@ public class StorageDescriptor implements org.apache.thrift.TBase<StorageDescrip
   // Return a generalized partition URI to support cross-cluster queries by extending the case with mount point to cover both cases,
   // including a special case, e.g., hadoop-dw2-nn.smf1.twitter.com/smf1/dw2/logs/hive_query_completion/2018/08/30/10, which has a dummy mount point.
   public String getLocation() {
+    if(this.location == null) {
+      return null;
+    }
     Configuration conf = new Configuration();
     URI fsURI = FileSystem.getDefaultUri(conf);
     Path path = new Path(this.location);


### PR DESCRIPTION
This change is to fix a bug reported in IQ-1452: CTAS query causes null string exception in Path() used in getLocation() if LOCATION is not specified. Add null checking in getLocation.