### PR TITLE
Fix substring index out of bound exception using modulo when index is…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -133,6 +133,8 @@ import org.apache.hive.common.util.ShutdownHookManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.lang.Math.floorMod;
+
 public class Driver implements CommandProcessor {
 
   static final private String CLASS_NAME = Driver.class.getName();
@@ -539,7 +541,7 @@ public class Driver implements CommandProcessor {
       conf.set("mapreduce.workflow.name", queryStr);
 
       String timeStamp = Long.toString(System.currentTimeMillis());
-      int filterInd = queryStr.toLowerCase().indexOf("where");
+      int filterInd = floorMod(queryStr.toLowerCase().indexOf("where"), queryStr.length());
       String appId = "hive_" + timeStamp + queryStr.substring(0, Math.min(filterInd, 80))
           .replace("select", "")
           .replace("from", "")


### PR DESCRIPTION
This PR uses modulo (math.floorMod()) to fix substring index out of bound exception when returned index is -1 (when keyword not found)